### PR TITLE
chore & fix(vue-virtual): fix package information & possible memory leak 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "./packages/react-virtual",
         "./packages/solid-virtual",
         "./packages/svelte-virtual",
+        "./packages/vue-virtual",
         "./examples/react/dynamic",
         "./examples/react/fixed",
         "./examples/react/infinite-scroll",
@@ -1130,7 +1131,6 @@
       "version": "7.20.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
       "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -5716,6 +5716,10 @@
       "resolved": "packages/virtual-core",
       "link": true
     },
+    "node_modules/@tanstack/vue-virtual": {
+      "resolved": "packages/vue-virtual",
+      "link": true
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
@@ -6239,7 +6243,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
       "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/shared": "3.2.36",
@@ -6250,14 +6253,12 @@
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.36.tgz",
       "integrity": "sha512-tcOTAOiW4s24QLnq+ON6J+GRONXJ+A/mqKCORi0LSlIh8XQlNnlm24y8xIL8la+ZDgkdbjarQ9ZqYSvEja6gVA==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-core": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -6267,7 +6268,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.36.tgz",
       "integrity": "sha512-AvGb4bTj4W8uQ4BqaSxo7UwTEqX5utdRSMyHy58OragWlt8nEACQ9mIeQh3K4di4/SX+41+pJrLIY01lHAOFOA==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.36",
@@ -6284,14 +6284,12 @@
     "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.36.tgz",
       "integrity": "sha512-+KugInUFRvOxEdLkZwE+W43BqHyhBh0jpYXhmqw1xGq2dmE6J9eZ8UUSOKNhdHtQ/iNLWWeK/wPZkVLUf3YGaw==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -6301,7 +6299,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.36.tgz",
       "integrity": "sha512-c2qvopo0crh9A4GXi2/2kfGYMxsJW4tVILrqRPydVGZHhq0fnzy6qmclWOhBFckEhmyxmpHpdJtIRYGeKcuhnA==",
-      "dev": true,
       "dependencies": {
         "@vue/shared": "3.2.36"
       }
@@ -6310,7 +6307,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.36.tgz",
       "integrity": "sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==",
-      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.36",
@@ -6322,14 +6318,12 @@
     "node_modules/@vue/reactivity-transform/node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@vue/runtime-core": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.36.tgz",
       "integrity": "sha512-PTWBD+Lub+1U3/KhbCExrfxyS14hstLX+cBboxVHaz+kXoiDLNDEYAovPtxeTutbqtClIXtft+wcGdC+FUQ9qQ==",
-      "dev": true,
       "dependencies": {
         "@vue/reactivity": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -6339,7 +6333,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.36.tgz",
       "integrity": "sha512-gYPYblm7QXHVuBohqNRRT7Wez0f2Mx2D40rb4fleehrJU9CnkjG0phhcGEZFfGwCmHZRqBCRgbFWE98bPULqkg==",
-      "dev": true,
       "dependencies": {
         "@vue/runtime-core": "3.2.36",
         "@vue/shared": "3.2.36",
@@ -6349,14 +6342,12 @@
     "node_modules/@vue/runtime-dom/node_modules/csstype": {
       "version": "2.6.20",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
-      "dev": true
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
     },
     "node_modules/@vue/server-renderer": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.36.tgz",
       "integrity": "sha512-uZE0+jfye6yYXWvAQYeHZv+f50sRryvy16uiqzk3jn8hEY8zTjI+rzlmZSGoE915k+W/Ol9XSw6vxOUD8dGkUg==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -6368,8 +6359,7 @@
     "node_modules/@vue/shared": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
-      "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
-      "dev": true
+      "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ=="
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -13065,7 +13055,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -13581,7 +13570,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14665,8 +14653,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -14717,7 +14704,6 @@
       "version": "8.4.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
       "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -16141,7 +16127,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16150,7 +16135,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17324,7 +17308,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.36.tgz",
       "integrity": "sha512-5yTXmrE6gW8IQgttzHW5bfBiFA6mx35ZXHjGLDmKYzW6MMmYvCwuKybANRepwkMYeXw2v1buGg3/lPICY5YlZw==",
-      "dev": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.36",
         "@vue/compiler-sfc": "3.2.36",
@@ -17828,6 +17811,24 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "packages/vue-virtual": {
+      "name": "@tanstack/vue-virtual",
+      "version": "3.0.0-beta.23",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0-beta.23"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     }
   },
   "dependencies": {
@@ -18164,8 +18165,7 @@
     "@babel/parser": {
       "version": "7.20.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
-      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
-      "dev": true
+      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -21584,6 +21584,12 @@
     "@tanstack/virtual-core": {
       "version": "file:packages/virtual-core"
     },
+    "@tanstack/vue-virtual": {
+      "version": "file:packages/vue-virtual",
+      "requires": {
+        "@tanstack/virtual-core": "3.0.0-beta.23"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
@@ -22034,7 +22040,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
       "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
-      "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/shared": "3.2.36",
@@ -22045,8 +22050,7 @@
         "estree-walker": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         }
       }
     },
@@ -22054,7 +22058,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.36.tgz",
       "integrity": "sha512-tcOTAOiW4s24QLnq+ON6J+GRONXJ+A/mqKCORi0LSlIh8XQlNnlm24y8xIL8la+ZDgkdbjarQ9ZqYSvEja6gVA==",
-      "dev": true,
       "requires": {
         "@vue/compiler-core": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -22064,7 +22067,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.36.tgz",
       "integrity": "sha512-AvGb4bTj4W8uQ4BqaSxo7UwTEqX5utdRSMyHy58OragWlt8nEACQ9mIeQh3K4di4/SX+41+pJrLIY01lHAOFOA==",
-      "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.36",
@@ -22081,8 +22083,7 @@
         "estree-walker": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         }
       }
     },
@@ -22090,7 +22091,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.36.tgz",
       "integrity": "sha512-+KugInUFRvOxEdLkZwE+W43BqHyhBh0jpYXhmqw1xGq2dmE6J9eZ8UUSOKNhdHtQ/iNLWWeK/wPZkVLUf3YGaw==",
-      "dev": true,
       "requires": {
         "@vue/compiler-dom": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -22100,7 +22100,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.36.tgz",
       "integrity": "sha512-c2qvopo0crh9A4GXi2/2kfGYMxsJW4tVILrqRPydVGZHhq0fnzy6qmclWOhBFckEhmyxmpHpdJtIRYGeKcuhnA==",
-      "dev": true,
       "requires": {
         "@vue/shared": "3.2.36"
       }
@@ -22109,7 +22108,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.36.tgz",
       "integrity": "sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==",
-      "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
         "@vue/compiler-core": "3.2.36",
@@ -22121,8 +22119,7 @@
         "estree-walker": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         }
       }
     },
@@ -22130,7 +22127,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.36.tgz",
       "integrity": "sha512-PTWBD+Lub+1U3/KhbCExrfxyS14hstLX+cBboxVHaz+kXoiDLNDEYAovPtxeTutbqtClIXtft+wcGdC+FUQ9qQ==",
-      "dev": true,
       "requires": {
         "@vue/reactivity": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -22140,7 +22136,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.36.tgz",
       "integrity": "sha512-gYPYblm7QXHVuBohqNRRT7Wez0f2Mx2D40rb4fleehrJU9CnkjG0phhcGEZFfGwCmHZRqBCRgbFWE98bPULqkg==",
-      "dev": true,
       "requires": {
         "@vue/runtime-core": "3.2.36",
         "@vue/shared": "3.2.36",
@@ -22150,8 +22145,7 @@
         "csstype": {
           "version": "2.6.20",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==",
-          "dev": true
+          "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
         }
       }
     },
@@ -22159,7 +22153,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.36.tgz",
       "integrity": "sha512-uZE0+jfye6yYXWvAQYeHZv+f50sRryvy16uiqzk3jn8hEY8zTjI+rzlmZSGoE915k+W/Ol9XSw6vxOUD8dGkUg==",
-      "dev": true,
       "requires": {
         "@vue/compiler-ssr": "3.2.36",
         "@vue/shared": "3.2.36"
@@ -22168,8 +22161,7 @@
     "@vue/shared": {
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
-      "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ==",
-      "dev": true
+      "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ=="
     },
     "abab": {
       "version": "2.0.5",
@@ -27239,7 +27231,6 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -27652,8 +27643,7 @@
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -28493,8 +28483,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -28527,7 +28516,6 @@
       "version": "8.4.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
       "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -29614,14 +29602,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-resolve": {
       "version": "0.6.0",
@@ -30842,7 +30828,6 @@
       "version": "3.2.36",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.36.tgz",
       "integrity": "sha512-5yTXmrE6gW8IQgttzHW5bfBiFA6mx35ZXHjGLDmKYzW6MMmYvCwuKybANRepwkMYeXw2v1buGg3/lPICY5YlZw==",
-      "dev": true,
       "requires": {
         "@vue/compiler-dom": "3.2.36",
         "@vue/compiler-sfc": "3.2.36",

--- a/packages/vue-virtual/package.json
+++ b/packages/vue-virtual/package.json
@@ -37,7 +37,7 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/virtual-core": "3.0.0-beta.18"
+    "@tanstack/virtual-core": "3.0.0-beta.23"
   },
   "peerDependencies": {
     "vue": "^3.0.0"

--- a/packages/vue-virtual/tsconfig.json
+++ b/packages/vue-virtual/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "outDir": "./build/types"
   },
-  "files": ["src/index.tsx"],
+  "files": ["src/index.ts"],
   "include": ["src"]
 }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -26,6 +26,12 @@ export const packages: Package[] = [
     srcDir: 'src',
     dependencies: ['@tanstack/virtual-core'],
   },
+  {
+    name: '@tanstack/vue-virtual',
+    packageDir: 'vue-virtual',
+    srcDir: 'src',
+    dependencies: ['@tanstack/virtual-core'],
+  }
 ]
 
 export const latestBranch = 'main'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,8 @@
       "@tanstack/virtual-core": ["packages/virtual-core"],
       "@tanstack/react-virtual": ["packages/react-virtual"],
       "@tanstack/solid-virtual": ["packages/solid-virtual"],
-      "@tanstack/svelte-virtual": ["packages/svelte-virtual"]
+      "@tanstack/svelte-virtual": ["packages/svelte-virtual"],
+      "@tanstack/vue-virtual": ["packages/vue-virtual"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     { "path": "packages/virtual-core" },
     { "path": "packages/react-virtual" },
     { "path": "packages/solid-virtual" },
-    { "path": "packages/svelte-virtual" }
+    { "path": "packages/svelte-virtual" },
+    { "path": "packages/vue-virtual" }
     // { "path": "examples/react/basic/tsconfig.dev.json" },
   ]
   // "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,25 +2234,31 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@tanstack/react-virtual@3.0.0-beta.23", "@tanstack/react-virtual@file:/home/runner/work/virtual/virtual/packages/react-virtual":
+"@tanstack/react-virtual@3.0.0-beta.23", "@tanstack/react-virtual@file:/Users/hoon/workspace/virtual/packages/react-virtual":
   "resolved" "file:packages/react-virtual"
   "version" "3.0.0-beta.23"
   dependencies:
     "@tanstack/virtual-core" "3.0.0-beta.23"
 
-"@tanstack/solid-virtual@file:/home/runner/work/virtual/virtual/packages/solid-virtual":
+"@tanstack/solid-virtual@file:/Users/hoon/workspace/virtual/packages/solid-virtual":
   "resolved" "file:packages/solid-virtual"
   "version" "3.0.0-beta.23"
   dependencies:
     "@tanstack/virtual-core" "3.0.0-beta.23"
 
-"@tanstack/svelte-virtual@file:/home/runner/work/virtual/virtual/packages/svelte-virtual":
+"@tanstack/svelte-virtual@file:/Users/hoon/workspace/virtual/packages/svelte-virtual":
   "resolved" "file:packages/svelte-virtual"
   "version" "3.0.0-beta.23"
 
-"@tanstack/virtual-core@3.0.0-beta.23", "@tanstack/virtual-core@file:/home/runner/work/virtual/virtual/packages/virtual-core":
+"@tanstack/virtual-core@3.0.0-beta.23", "@tanstack/virtual-core@file:/Users/hoon/workspace/virtual/packages/virtual-core":
   "resolved" "file:packages/virtual-core"
   "version" "3.0.0-beta.23"
+
+"@tanstack/vue-virtual@file:/Users/hoon/workspace/virtual/packages/vue-virtual":
+  "resolved" "file:packages/vue-virtual"
+  "version" "3.0.0-beta.23"
+  dependencies:
+    "@tanstack/virtual-core" "3.0.0-beta.23"
 
 "@testing-library/dom@^8.0.0":
   "integrity" "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ=="
@@ -3874,14 +3880,14 @@
     "is-date-object" "^1.0.1"
     "is-symbol" "^1.0.2"
 
-"esbuild-linux-64@0.14.42":
-  "integrity" "sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA=="
-  "resolved" "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz"
+"esbuild-darwin-arm64@0.14.42":
+  "integrity" "sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA=="
+  "resolved" "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz"
   "version" "0.14.42"
 
-"esbuild-linux-64@0.15.14":
-  "integrity" "sha512-ONySx3U0wAJOJuxGUlXBWxVKFVpWv88JEv0NZ6NlHknmDd1yCbf4AEdClSgLrqKQDXYywmw4gYDvdLsS6z0hcw=="
-  "resolved" "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.14.tgz"
+"esbuild-darwin-arm64@0.15.14":
+  "integrity" "sha512-KgGP+y77GszfYJgceO0Wi/PiRtYo5y2Xo9rhBUpxTPaBgWDJ14gqYN0+NMbu+qC2fykxXaipHxN4Scaj9tUS1A=="
+  "resolved" "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.14.tgz"
   "version" "0.15.14"
 
 "esbuild@^0.14.27":
@@ -4220,6 +4226,11 @@
   "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8= sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
+
+"fsevents@^2.3.2", "fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
@@ -7780,7 +7791,7 @@
   "resolved" "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
   "version" "3.2.4"
 
-"tanstack-react-virtual-example-dynamic@file:/home/runner/work/virtual/virtual/examples/react/dynamic":
+"tanstack-react-virtual-example-dynamic@file:/Users/hoon/workspace/virtual/examples/react/dynamic":
   "resolved" "file:examples/react/dynamic"
   "version" "0.0.0"
   dependencies:
@@ -7789,7 +7800,7 @@
     "react" "^18.2.0"
     "react-dom" "^18.2.0"
 
-"tanstack-react-virtual-example-fixed@file:/home/runner/work/virtual/virtual/examples/react/fixed":
+"tanstack-react-virtual-example-fixed@file:/Users/hoon/workspace/virtual/examples/react/fixed":
   "resolved" "file:examples/react/fixed"
   "version" "0.0.0"
   dependencies:
@@ -7797,7 +7808,7 @@
     "react" "^17.0.2"
     "react-dom" "^17.0.2"
 
-"tanstack-react-virtual-example-infinite-scroll@file:/home/runner/work/virtual/virtual/examples/react/infinite-scroll":
+"tanstack-react-virtual-example-infinite-scroll@file:/Users/hoon/workspace/virtual/examples/react/infinite-scroll":
   "resolved" "file:examples/react/infinite-scroll"
   "version" "0.0.0"
   dependencies:
@@ -7806,7 +7817,7 @@
     "react-dom" "^17.0.2"
     "react-query" "^3.39.1"
 
-"tanstack-react-virtual-example-padding@file:/home/runner/work/virtual/virtual/examples/react/padding":
+"tanstack-react-virtual-example-padding@file:/Users/hoon/workspace/virtual/examples/react/padding":
   "resolved" "file:examples/react/padding"
   "version" "0.0.0"
   dependencies:
@@ -7814,7 +7825,7 @@
     "react" "^17.0.2"
     "react-dom" "^17.0.2"
 
-"tanstack-react-virtual-example-scroll-padding@file:/home/runner/work/virtual/virtual/examples/react/scroll-padding":
+"tanstack-react-virtual-example-scroll-padding@file:/Users/hoon/workspace/virtual/examples/react/scroll-padding":
   "resolved" "file:examples/react/scroll-padding"
   "version" "0.0.0"
   dependencies:
@@ -7823,7 +7834,7 @@
     "react" "^17.0.2"
     "react-dom" "^17.0.2"
 
-"tanstack-react-virtual-example-smooth-scroll@file:/home/runner/work/virtual/virtual/examples/react/smooth-scroll":
+"tanstack-react-virtual-example-smooth-scroll@file:/Users/hoon/workspace/virtual/examples/react/smooth-scroll":
   "resolved" "file:examples/react/smooth-scroll"
   "version" "0.0.0"
   dependencies:
@@ -7831,7 +7842,7 @@
     "react" "^17.0.2"
     "react-dom" "^17.0.2"
 
-"tanstack-react-virtual-example-sticky@file:/home/runner/work/virtual/virtual/examples/react/sticky":
+"tanstack-react-virtual-example-sticky@file:/Users/hoon/workspace/virtual/examples/react/sticky":
   "resolved" "file:examples/react/sticky"
   "version" "0.0.0"
   dependencies:
@@ -7840,7 +7851,7 @@
     "react" "^17.0.2"
     "react-dom" "^17.0.2"
 
-"tanstack-react-virtual-example-variable@file:/home/runner/work/virtual/virtual/examples/react/variable":
+"tanstack-react-virtual-example-variable@file:/Users/hoon/workspace/virtual/examples/react/variable":
   "resolved" "file:examples/react/variable"
   "version" "0.0.0"
   dependencies:
@@ -8312,7 +8323,7 @@
   optionalDependencies:
     "fsevents" "~2.3.2"
 
-"vue@^3.2.33", "vue@3.2.36":
+"vue@^3.0.0", "vue@^3.2.33", "vue@3.2.36":
   "integrity" "sha512-5yTXmrE6gW8IQgttzHW5bfBiFA6mx35ZXHjGLDmKYzW6MMmYvCwuKybANRepwkMYeXw2v1buGg3/lPICY5YlZw=="
   "resolved" "https://registry.npmjs.org/vue/-/vue-3.2.36.tgz"
   "version" "3.2.36"


### PR DESCRIPTION
chore(vue-virtual)
- upgrade virtual-core dependency to 3.0.0-beta.23
- update tsconfig and script config files to correctly map vue-virtual.

fix(vue-virtual)
- fix possible memory leak by calling doClean during unmounting.